### PR TITLE
Remove `priority` tag

### DIFF
--- a/data/cheater plugin.txt
+++ b/data/cheater plugin.txt
@@ -53,7 +53,6 @@ conversation "all-content plugin start"
 
 
 mission "All-Content Start"
-	priority
 	landing
 	invisible
 	name `The all-content-plugin's start mission`


### PR DESCRIPTION
According to the game:
> Warning: "priority" tag has no effect on "landing" missions:
> file "/home/user/.local/share/endless-sky/plugins/All Content Plugin/data/cheater plugin.txt"
>     mission "All-Content Start"